### PR TITLE
allow data with subset of nucleotides to be processed

### DIFF
--- a/R/genind2hierfstat.R
+++ b/R/genind2hierfstat.R
@@ -43,7 +43,7 @@ genind2hierfstat<-function(dat,pop=NULL){
   nucleotides<-c("A","C","G","T")
   alleles.name<-toupper(names(table(unlist(dat@all.names))))
   nuc<-FALSE
-  if(identical(alleles.name,nucleotides)) nuc<-TRUE
+  if(all(alleles.name %in% nucleotides)) nuc<-TRUE
   
 
   x<-genind2df(dat,sep="",usepop=FALSE)


### PR DESCRIPTION
Data sets that only represent a subset of nucleotides (eg A, C, T, but not G) are currently rejected. This was discovered in https://github.com/NESCent/popgenInfo/pull/87#issuecomment-165166528

I've changed `identical(alleles.name, nucleotides)` to `all(alleles.name %in% nucleotides)`