### PR TITLE
Add parallel processing to varcomp.glob and boot.vc function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hierfstat
-Version: 0.5-11
-Date: 2022-05-03
+Version: 0.5-12
+Date: 2026-06-18
 Title: Estimation and Tests of Hierarchical F-Statistics
 Authors@R: c(person("Jerome","Goudet",role=c("aut","cre"),email="jerome.goudet@unil.ch"),
              person("Thibaut","Jombart",role="aut",email="t.jombart@imperial.ac.uk"),
@@ -14,7 +14,7 @@ Author: Jerome Goudet [aut, cre],
     Olivier Hardy [ctb]
 Maintainer: Jerome Goudet <jerome.goudet@unil.ch>
 Imports:
-    ade4,adegenet,gaston,gtools,methods
+    ade4,adegenet,gaston,gtools,methods,parallel
 Suggests:
     ape,
     pegas,

--- a/R/boot.R
+++ b/R/boot.R
@@ -2,7 +2,7 @@
 
 #' @export
 boot.vc<-function (levels = levels, loci = loci, diploid = TRUE, nboot = 1000, 
-    quant = c(0.025, 0.5, 0.975)) 
+    quant = c(0.025, 0.5, 0.975), n.cores=1) 
 {
     gf <- function(dat, num, den) {
         sum(dat[num])/sum(dat[den])
@@ -11,7 +11,7 @@ boot.vc<-function (levels = levels, loci = loci, diploid = TRUE, nboot = 1000,
     if (nloc < 5) {
         stop("Not enough loci to bootstrap. Exiting")
     }
-    x <- varcomp.glob(levels = levels, loci = loci, diploid = diploid)
+    x <- varcomp.glob(levels = levels, loci = loci, diploid = diploid, n.cores=n.cores)
     x.loc <- data.frame(x$loc)
     rows<-stats::complete.cases(x.loc)
     if(sum(rows)<5){

--- a/R/varcomp.R
+++ b/R/varcomp.R
@@ -90,35 +90,66 @@
 #'@export
 
 "varcomp.glob" <-
-  function (levels = levels, loci = loci, diploid = TRUE) 
-  {
-    lnames <- names(loci)
-    if (is.null(dim(levels))) {
-      fnames <- "Pop"
-    }
-    else fnames <- names(levels)
-    if (diploid) {
-      fnames <- c(fnames, "Ind")
-    }
-    res <- varcomp(cbind(levels, loci[, 1]),diploid)$overall #OPT: remove cbind and rbind
-    nloc <- dim(loci)[2]
-    for (i in 2:nloc) res <- rbind(res, varcomp(cbind(levels, 
-                                                      loci[, i]),diploid)$overall) #OPT
-    tot <- apply(res, 2, sum, na.rm = TRUE)
-    nblevels <- length(tot)
-    f <- matrix(rep(0, (nblevels - 1)^2), ncol = (nblevels - 
-                                                    1))
-    for (i in 1:(nblevels - 1)) {
-      for (j in i:(nblevels - 1)) {
-        f[i, j] <- sum(tot[i:j])/sum(tot[i:nblevels])
-      }
-    }
-    fnames
-    row.names(res) <- lnames
-    names(tot) <- c(fnames, "Error")
-    tf <- t(f)
-    row.names(tf) <- fnames
-    f <- t(tf)
-    row.names(f) <- c("Total", fnames[-length(fnames)])
-    return(list(loc = res, overall = tot, F = f))
+  function (levels = levels, loci = loci, diploid = TRUE, n.cores = 1) 
+{
+  lnames <- names(loci)
+  if (is.null(dim(levels))) {
+    fnames <- "Pop"
   }
+  else fnames <- names(levels)
+  if (diploid) {
+    fnames <- c(fnames, "Ind")
+  }
+  
+  nloc <- dim(loci)[2]
+  
+  if (!is.null(n.cores) && n.cores > 1) {
+    
+    cores.disponiveis <- parallel::detectCores()
+    
+    if (n.cores >= cores.disponiveis) {
+      n.cores <- max(1, cores.disponiveis - 1)
+      message(paste("Adjusting n.cores to", n.cores, "to prevent system crash."))
+    }
+    
+    message(paste("Processing", nloc, "loci using", n.cores, "cores..."))
+    
+    if (.Platform$OS.type == "unix") {
+      lista_res <- parallel::mclapply(1:nloc, function(i) {
+        varcomp(cbind(levels, loci[, i]), diploid)$overall
+      }, mc.cores = n.cores)
+    } else {
+      cl <- parallel::makeCluster(n.cores)
+      on.exit(parallel::stopCluster(cl))       
+      parallel::clusterExport(cl, varlist = c("levels", "loci", "diploid"), envir = environment())
+      parallel::clusterEvalQ(cl, library(hierfstat))
+      
+      lista_res <- parallel::parLapply(cl, 1:nloc, function(i) {
+        varcomp(cbind(levels, loci[, i]), diploid)$overall
+      })
+    }
+    res <- do.call(rbind, lista_res)
+    
+  } else {
+    lista_res <- lapply(1:nloc, function(i) {
+      varcomp(cbind(levels, loci[, i]), diploid)$overall
+    })
+    res <- do.call(rbind, lista_res)
+  }
+  
+  tot <- apply(res, 2, sum, na.rm = TRUE)
+  nblevels <- length(tot)
+  f <- matrix(rep(0, (nblevels - 1)^2), ncol = (nblevels - 1))
+  for (i in 1:(nblevels - 1)) {
+    for (j in i:(nblevels - 1)) {
+      f[i, j] <- sum(tot[i:j])/sum(tot[i:nblevels])
+    }
+  }
+  row.names(res) <- lnames
+  names(tot) <- c(fnames, "Error")
+  tf <- t(f)
+  row.names(tf) <- fnames
+  f <- t(tf)
+  row.names(f) <- c("Total", fnames[-length(fnames)])
+  return(list(loc = res, overall = tot, F = f))
+}

--- a/man/boot.vc.Rd
+++ b/man/boot.vc.Rd
@@ -3,7 +3,7 @@
 \title{Bootstrap confidence intervals for variance components}
 \description{Provides a bootstrap confidence interval (over loci) for sums of the different variance components (equivalent to gene diversity estimates at the different levels), and the  derived F-statistics, as suggested by Weir and Cockerham (1984). Will not run with less than 5 loci. Raymond and Rousset (199X) points out shortcomings of this method.}
 \usage{
-boot.vc(levels=levels,loci=loci,diploid=TRUE,nboot=1000,quant=c(0.025,0.5,0.975))
+boot.vc(levels=levels,loci=loci,diploid=TRUE,nboot=1000,quant=c(0.025,0.5,0.975),n.cores=1)
 }
 \arguments{
 \item{levels}{a data frame containing the different levels (factors) from the outermost (e.g. region) to the innermost before the individual}
@@ -11,6 +11,7 @@ boot.vc(levels=levels,loci=loci,diploid=TRUE,nboot=1000,quant=c(0.025,0.5,0.975)
 \item{diploid}{Specify whether the data are coming from diploid or haploid organisms (diploid is the default)}
 \item{nboot}{Specify the number of bootstrap to carry out. Default is 1000}
 \item{quant}{Specify which quantile to produce. Default is c(0.025,0.5,0.975) giving the percentile 95\% CI and the median}
+\item{n.cores}{number of threads to perform the calculation (default is n.cores=1)}
 }
 \value{
 \item{boot}{a data frame with the bootstrapped variance components. Could be used for obtaining bootstrap ci of statistics not listed here.}

--- a/man/varcomp.glob.Rd
+++ b/man/varcomp.glob.Rd
@@ -3,12 +3,13 @@
 \title{Estimate variance components and hierarchical F-statistics over all loci}
 \description{Return multilocus estimators of variance components and F-statistics}
 \usage{
-varcomp.glob(levels=levels,loci=loci,diploid=TRUE)
+varcomp.glob(levels=levels,loci=loci,diploid=TRUE, n.cores=1)
 }
 \arguments{
 \item{levels}{a data frame containing the different levels (factors) from the outermost (e.g. region) to the innermost before the individual}
 \item{loci}{a data frame containing the different loci}
 \item{diploid}{Specify whether the data are coming from diploid or haploid organisms (diploid is the default)}
+\item{n.cores}{number of threads to perform the calculation (default is n.cores=1)}
 }
 \value{
 \item{loc}{The variance components for each locus}


### PR DESCRIPTION
Dear Dr. Jerome Goudet,

I have submitted a Pull Request to optimize the varcomp.glob and boot.vc functions, improving its performance for large datasets. Here is a brief summary of the changes:

- Elimination of the rbind bottleneck: Replaced the sequential for loop that used rbind with a cleaner lapply + do.call(rbind, ...) approach. This avoids continuous memory re-allocation and speeds up the function.

- Parallelization support (n.cores): Added multi-core support using the parallel package. The default value is set to n.cores = 1 to respect CRAN policies. Additionally, there is automated check to ensure the function downscales the requested cores if it exceeds the system's capacity, preventing accidental crashes.

Thank you for your time.

Best regards,